### PR TITLE
Switch to CanvasAnimatedControl

### DIFF
--- a/EvilEvolved/EvilEvolved/GameTimer.cs
+++ b/EvilEvolved/EvilEvolved/GameTimer.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Windows.UI.Xaml;
 using Microsoft.Graphics.Canvas.UI.Xaml;
 
 namespace EvilutionClass
@@ -14,27 +8,20 @@ namespace EvilutionClass
     /// </summary>
     public class GameTimer
     {
+        private bool IsUpdating = false;
+        private TimeSpan TotalAppTime;
+        private DateTime LastUpdateTime;
+        private DateTime LastDrawTime;
+        private TimeSpan TimeBetweenDraw;
+
         /// <summary>
         /// GameTimer constructor, sets default values.
         /// </summary>
-        public GameTimer(CanvasControl surface = null, int UPS = 120, int FPS = 60)
+        public GameTimer()
         {
-
-            UpdateTimer = new DispatcherTimer();
-            UpdateTimer.Interval = TimeSpan.FromMilliseconds(1000 / UPS); //60ups
-            UpdateTimer.Tick += UpdateTimer_Tick;
-
-            //set FPS
-            TimeBetweenDraw = TimeSpan.FromMilliseconds(1000 / FPS); //30fps
-
             //initialise LastUpdate and LastDraw to current time
             LastUpdateTime = DateTime.Now;
             LastDrawTime = DateTime.Now;
-
-            ParentCanvas = surface;
-
-            UpdateTimer.Start();
-
         }
 
         /// <summary>
@@ -42,82 +29,59 @@ namespace EvilutionClass
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
-        void UpdateTimer_Tick(object sender, object e)
+        public void OnUpdate(ICanvasAnimatedControl sender)
         {
-            if (!IsUpdating)
+            //find delta t
+            var dt = DateTime.Now - LastUpdateTime;
+
+            //Update LastUpdateTime
+            LastUpdateTime = DateTime.Now;
+
+            //Update the total app time
+            TotalAppTime += dt;
+
+            //get the current input from the input manager
+            var gi = InputManager.Update();
+            var gm = MessageManager.Update();
+
+            if (StoryBoard.Update(dt, gm))
             {
-                IsUpdating = true;
-                //find delta t
-                TimeSpan dt = DateTime.Now - LastUpdateTime;
 
-                //Update LastUpdateTime
-                LastUpdateTime = DateTime.Now;
-
-                //Update the total app time
-                TotalAppTime += dt;
-
-                //get the current input from the input manager
-                GenericInput gi = InputManager.Update();
-                GenericMessage gm = MessageManager.Update();
-
-                if (StoryBoard.Update(dt, gm))
-                {
-
-                }
-                else
-                {
-                    if (null != StoryBoard.CurrentScene)
-                    {
-                        StoryBoard.CurrentScene.Update(dt, gi);
-                        StoryBoard.CurrentScene.Update(dt, gm);
-                        gi = InputManager.PeekAndTake(typeof(MouseGenericInput));
-                        while (gi is MouseGenericInput)
-                        {
-                            StoryBoard.CurrentScene.Update(TimeSpan.Zero, gi);
-                            gi = InputManager.PeekAndTake(typeof(MouseGenericInput));
-                        }
-                        gm = MessageManager.PeekAndTake(typeof(Message_Attack));
-                        while (gm is Message_Attack)
-                        {
-                            StoryBoard.CurrentScene.Update(TimeSpan.Zero, gm);
-                            gm = MessageManager.PeekAndTake(typeof(Message_Attack));
-                        }                        
-                        gi = InputManager.PeekAndTake(typeof(Message_Collision));
-                        while (gm is Message_Collision)
-                        {
-                            StoryBoard.CurrentScene.Update(TimeSpan.Zero, gm);
-                            gm = MessageManager.PeekAndTake(typeof(Message_Collision));
-                        }
-                    }
-                }
-
-                //Figure out if we need to refresh the screen
-                TimeSpan dt_Draw = DateTime.Now - LastDrawTime;
-                if(dt_Draw.Milliseconds > TimeBetweenDraw.Milliseconds)
-                {
-                    //call refresh
-                    if(null != ParentCanvas)
-                    {
-                        ParentCanvas.Invalidate();
-                        LastDrawTime = DateTime.Now;
-                    }
-                    
-                }
-
-                IsUpdating = false;
             }
+            else
+            {
+                if (null != StoryBoard.CurrentScene)
+                {
+                    StoryBoard.CurrentScene.Update(dt, gi);
+                    StoryBoard.CurrentScene.Update(dt, gm);
+                    gi = InputManager.PeekAndTake(typeof(MouseGenericInput));
+                    while (gi is MouseGenericInput)
+                    {
+                        StoryBoard.CurrentScene.Update(TimeSpan.Zero, gi);
+                        gi = InputManager.PeekAndTake(typeof(MouseGenericInput));
+                    }
+                    gm = MessageManager.PeekAndTake(typeof(Message_Attack));
+                    while (gm is Message_Attack)
+                    {
+                        StoryBoard.CurrentScene.Update(TimeSpan.Zero, gm);
+                        gm = MessageManager.PeekAndTake(typeof(Message_Attack));
+                    }                        
+                    gi = InputManager.PeekAndTake(typeof(Message_Collision));
+                    while (gm is Message_Collision)
+                    {
+                        StoryBoard.CurrentScene.Update(TimeSpan.Zero, gm);
+                        gm = MessageManager.PeekAndTake(typeof(Message_Collision));
+                    }
+                }
+            }
+
+            //Figure out if we need to refresh the screen
+            var dt_Draw = DateTime.Now - LastDrawTime;
+            if(dt_Draw.Milliseconds > TimeBetweenDraw.Milliseconds)
+            {
+                LastDrawTime = DateTime.Now;
+                
+            }            
         }
-
-        #region -----[Properties]
-
-        private bool IsUpdating = false;
-        private DispatcherTimer UpdateTimer;
-        private TimeSpan TotalAppTime;
-        private DateTime LastUpdateTime;
-        private DateTime LastDrawTime;
-        private TimeSpan TimeBetweenDraw;
-        private CanvasControl ParentCanvas;
-
-        #endregion
     }
 }

--- a/EvilEvolved/EvilEvolved/ImageManager.cs
+++ b/EvilEvolved/EvilEvolved/ImageManager.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
-
 using Microsoft.Graphics.Canvas;
 using Microsoft.Graphics.Canvas.UI.Xaml;
 
@@ -40,7 +37,7 @@ namespace EvilutionClass
 
         }
 
-        static public CanvasControl ParentCanvas = null;
+        static public ICanvasAnimatedControl ParentCanvas = null;
 
     }
 }

--- a/EvilEvolved/EvilEvolved/MainPage.xaml
+++ b/EvilEvolved/EvilEvolved/MainPage.xaml
@@ -5,20 +5,24 @@
     xmlns:canvas="using:Microsoft.Graphics.Canvas.UI.Xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:Windows10FallCreatorsUpdate="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 5)"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
 
     <Grid>
-        <canvas:CanvasControl Draw="CanvasControl_Draw" 
-                              ClearColor="Black" 
-                              CreateResources="CanvasControl_CreateResources" 
-                              PointerMoved="CanvasControl_PointerMoved" 
-                              PointerPressed="CanvasControl_PointerPressed" 
-                              PointerReleased="CanvasControl_PointerReleased" 
-                              KeyDown="CanvasControl_KeyDown" 
-                              KeyUp="CanvasControl_KeyUp"
-                              IsTabStop="True"
-                              />
+        <canvas:CanvasAnimatedControl
+            x:Name="Cvs"
+            ClearColor="Black"
+            IsFixedTimeStep="False"
+            CreateResources="OnCreateResources"
+            Draw="OnDraw"
+            GameLoopStarting="OnGameLoopStarting"
+            GameLoopStopped="OnGameLoopStopped"
+            Update="OnUpdate"
+            PointerMoved="CanvasControl_PointerMoved"
+            PointerPressed="CanvasControl_PointerPressed"
+            PointerReleased="CanvasControl_PointerReleased"
+            KeyDown="CanvasControl_KeyDown"
+            KeyUp="CanvasControl_KeyUp"
+            IsTabStop="True" />
     </Grid>
 </Page>

--- a/EvilEvolved/EvilEvolved/Scenes/GameScene.cs
+++ b/EvilEvolved/EvilEvolved/Scenes/GameScene.cs
@@ -1,21 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using System.Text;
-using System.Threading.Tasks;
-using Windows.Foundation;
 using Windows.Media.Playback;
-using Windows.Media;
 using Windows.UI;
-using Windows.UI.Xaml;
 using Microsoft.Graphics.Canvas;
-using Windows.Graphics.Imaging;
-using Microsoft.Graphics.Canvas.Effects;
-using Windows.UI.Xaml.Media;
-using Windows.UI.Xaml.Controls;
-using Windows.UI.Xaml.Media.Imaging;
-using Windows.UI.Xaml.Shapes;
 
 namespace EvilutionClass
 {
@@ -92,7 +79,10 @@ namespace EvilutionClass
                             {
                                 foreach (Villain villain in villains)
                                 {
-                                    if (RectHelper.Intersect(villain.BoundingRectangle, gi.BoundingRectangle) != Rect.Empty)
+                                    var villainRect = villain.BoundingRectangle;
+                                    villainRect.Intersect(gi.BoundingRectangle);
+
+                                    if (!villainRect.IsEmpty)
                                     {
                                         villain.TimeSinceCollision = DateTime.Now - villain.LastCollision;
                                         if (villain.TimeSinceCollision.TotalMilliseconds > villain.iFrames)
@@ -114,7 +104,10 @@ namespace EvilutionClass
                             {
                                 foreach (Hero hero in heros)
                                 {
-                                    if (RectHelper.Intersect(hero.BoundingRectangle, gi.BoundingRectangle) != Rect.Empty)
+                                    var heroRect = hero.BoundingRectangle;
+                                    heroRect.Intersect(gi.BoundingRectangle);
+
+                                    if (!heroRect.IsEmpty)
                                     {
                                         hero.TimeSinceCollision = DateTime.Now - hero.LastCollision;
                                         if (hero.TimeSinceCollision.TotalMilliseconds > hero.iFrames)


### PR DESCRIPTION
Replaces the use of the CanvasControl with the CanvasAnimatedControl, which handles timing for us. #2 

Because of the threading model that the CAC uses, the method of calculating intersections in GameScene could no longer use RectHelper.